### PR TITLE
(#83) Added result counting in the list operations output

### DIFF
--- a/dotnet/server/src/Azure.Mobile.Server/Utils/PagedListResult{T}.cs
+++ b/dotnet/server/src/Azure.Mobile.Server/Utils/PagedListResult{T}.cs
@@ -12,7 +12,7 @@ namespace Azure.Mobile.Server.Utils
         /// <summary>
         /// The list of entities in this result set.
         /// </summary>
-        public IEnumerable<T> Values { get; set; }
+        public IList<T> Values { get; set; }
 
         /// <summary>
         /// An opaque Uri for requesting the next page - null if no more pages.
@@ -23,5 +23,15 @@ namespace Azure.Mobile.Server.Utils
         /// The count of items in the list without paging.
         /// </summary>
         public long? Count { get; set; }
+
+        /// <summary>
+        /// The maximum value of the $top query parameter
+        /// </summary>
+        public long? MaxTop { get; set; }
+
+        /// <summary>
+        /// The size for server-side paging.
+        /// </summary>
+        public long? PageSize { get; set; }
     }
 }

--- a/dotnet/server/test/Azure.Mobile.Server.Test/Helpers/PagedList.cs
+++ b/dotnet/server/test/Azure.Mobile.Server.Test/Helpers/PagedList.cs
@@ -23,5 +23,15 @@ namespace Azure.Mobile.Server.Test.Helpers
         /// The count of items in the list without paging.
         /// </summary>
         public long? Count { get; set; }
+
+        /// <summary>
+        /// The maximum value of $top that the user can provide
+        /// </summary>
+        public long? MaxTop { get; set; }
+
+        /// <summary>
+        /// The maximum number of items that the service will return.
+        /// </summary>
+        public long? PageSize { get; set; }
     }
 }

--- a/dotnet/server/test/Azure.Mobile.Server.Test/TableController/List.Test.cs
+++ b/dotnet/server/test/Azure.Mobile.Server.Test/TableController/List.Test.cs
@@ -24,10 +24,44 @@ namespace Azure.Mobile.Server.Test.TableController
             CollectionAssert.AllItemsAreUnique(actual.Values);
             Assert.AreEqual(50, actual.Values.Count);
             Assert.IsNotNull(actual.NextLink);
+            Assert.IsNotNull(actual.Count);
+            Assert.AreEqual(248, actual.Count);
+        }
 
-            // TODO: This does not work right now because GetEntityCount() information in GetItems() . 
-            //Assert.IsNotNull(actual.Count);
-            //Assert.AreEqual(248, actual.Count);
+        [TestMethod]
+        public async Task GetItems_WithFilter_ReturnsSomeItems()
+        {
+            var response = await SendRequestToServer<Movie>(HttpMethod.Get, "/tables/movies?$filter=mpaaRating eq 'R'&$count=true", null);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+            var actual = await GetValueFromResponse<PagedList<Movie>>(response);
+            Assert.IsNotNull(actual);
+            CollectionAssert.AllItemsAreNotNull(actual.Values);
+            CollectionAssert.AllItemsAreUnique(actual.Values);
+            Assert.AreEqual(50, actual.Values.Count);
+            Assert.IsNotNull(actual.NextLink);
+            Assert.IsNotNull(actual.Count);
+            Assert.AreEqual(94, actual.Count);
+            Assert.IsNotNull(actual.MaxTop);
+            Assert.IsNotNull(actual.PageSize);
+        }
+
+        [TestMethod]
+        public async Task GetItems_ExcludingItems_ReturnsSomeItems()
+        {
+            var response = await SendRequestToServer<Movie>(HttpMethod.Get, "/tables/movies?$filter=mpaaRating eq 'R'&$count=true&__excludeitems=true", null);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+            var actual = await GetValueFromResponse<PagedList<Movie>>(response);
+            Assert.IsNotNull(actual);
+            Assert.IsNull(actual.Values);
+            Assert.IsNull(actual.NextLink);
+            Assert.IsNotNull(actual.Count);
+            Assert.AreEqual(94, actual.Count);
+            Assert.IsNotNull(actual.MaxTop);
+            Assert.IsTrue(actual.MaxTop > 0);
+            Assert.IsNotNull(actual.PageSize);
+            Assert.IsTrue(actual.PageSize > 0);
         }
 
         [TestMethod]


### PR DESCRIPTION
Added support for:

* $count=true
* __excludeitems=true

Within the list operation.  The former provides the count of items in the query, and the latter excludes the items from the response, allowing us to count without iterating.

Also added tests to this to test it.