### PR TITLE
(#165) Refactor of the ValidateOperationAsync function

### DIFF
--- a/dotnet/client/test/Microsoft.Zumo.MobileData.Test/Table/MobileDataTable.Test.cs
+++ b/dotnet/client/test/Microsoft.Zumo.MobileData.Test/Table/MobileDataTable.Test.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public async Task GetMetadataAsync_NotAuthorized_Returns404()
+        public async Task GetMetadataAsync_NotAuthorized_Returns403()
         {
             var client = GetTestClient();
             var table = client.GetTable<Movie>("tables/unauthorized");
@@ -130,7 +130,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 
@@ -232,7 +232,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public void GetMetadata_NotAuthorized_Returns404()
+        public void GetMetadata_NotAuthorized_Returns403()
         {
             var client = GetTestClient();
             var table = client.GetTable<Movie>("tables/unauthorized");
@@ -244,7 +244,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 
@@ -281,7 +281,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public async Task GetItemAsync_NotAuthorized_Returns404()
+        public async Task GetItemAsync_NotAuthorized_Returns403()
         {
             var client = GetTestClient();
             var table = client.GetTable<Movie>("tables/unauthorized");
@@ -294,7 +294,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 
@@ -363,7 +363,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public void GetItem_NotAuthorized_Returns404()
+        public void GetItem_NotAuthorized_Returns403()
         {
             var client = GetTestClient();
             var table = client.GetTable<Movie>("tables/unauthorized");
@@ -375,7 +375,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 
@@ -582,7 +582,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public async Task GetItemsAsync_NotAuthorized_Returns404()
+        public async Task GetItemsAsync_NotAuthorized_Returns403()
         {
             var client = GetTestClient();
             var table = client.GetTable<Movie>("tables/unauthorized");
@@ -595,7 +595,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 
@@ -739,7 +739,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public void GetItems_NotAuthorized_Returns404()
+        public void GetItems_NotAuthorized_Returns403()
         {
             var client = GetTestClient();
             var table = client.GetTable<Movie>("tables/unauthorized");
@@ -751,7 +751,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 
@@ -801,12 +801,12 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public async Task CreateItemAsync_NotAuthorized_Returns401()
+        public async Task CreateItemAsync_NotAuthorized_Returns403()
         {
             var item = new Unit
             {
                 Id = Guid.NewGuid().ToString("N"),
-                Data = "create-item-missing-item-returns-201"
+                Data = "createitemasync-notauthorized-returns403"
             };
 
             var client = GetTestClient();
@@ -822,7 +822,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(401, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
 
             var dbItem = DbContext.HUnits.Where(m => m.Id == item.Id);
@@ -924,12 +924,12 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public void CreateItem_NotAuthorized_Returns401()
+        public void CreateItem_NotAuthorized_Returns403()
         {
             var item = new Unit
             {
                 Id = Guid.NewGuid().ToString("N"),
-                Data = "create-item-missing-item-returns-201"
+                Data = "createitem-notauthorized-returns403"
             };
 
             var client = GetTestClient();
@@ -945,7 +945,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(401, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
 
             var dbItem = DbContext.HUnits.Where(m => m.Id == item.Id);
@@ -1134,7 +1134,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public async Task DeleteItemAsync_Unauthorized_Returns404()
+        public async Task DeleteItemAsync_Unauthorized_Returns403()
         {
             var item = new Movie { Id = "movie-3" };
 
@@ -1148,7 +1148,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 
@@ -1345,7 +1345,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public void DeleteItem_Unauthorized_Returns404()
+        public void DeleteItem_Unauthorized_Returns403()
         {
             var item = new Movie { Id = "movie-3" };
 
@@ -1359,7 +1359,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 
@@ -1530,7 +1530,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public async Task ReplaceItemAsync_Unauthorized_Returns404()
+        public async Task ReplaceItemAsync_Unauthorized_Returns403()
         {
             var client = GetTestClient();
             var table = client.GetTable<Movie>("tables/unauthorized");
@@ -1545,7 +1545,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 
@@ -1684,7 +1684,7 @@ namespace Microsoft.Zumo.MobileData.Test
         }
 
         [TestMethod]
-        public void ReplaceItem_Unauthorized_Returns404()
+        public void ReplaceItem_Unauthorized_Returns403()
         {
             var client = GetTestClient();
             var table = client.GetTable<Movie>("tables/unauthorized");
@@ -1699,7 +1699,7 @@ namespace Microsoft.Zumo.MobileData.Test
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.AreEqual(403, ex.Status);
             }
         }
 

--- a/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/Create.Test.cs
+++ b/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/Create.Test.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Zumo.Server.Test.TableController
         }
 
         [TestMethod]
-        public async Task CreateItem_NotAuthorized_Returns401()
+        public async Task CreateItem_NotAuthorized_Returns403()
         {
             var item = new HUnit
             {
@@ -51,7 +51,7 @@ namespace Microsoft.Zumo.Server.Test.TableController
             };
             var response = await SendRequestToServer<HUnit>(HttpMethod.Post, "tables/unauthorized", item);
 
-            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
 
             var dbItem = GetItemFromDb<HUnit>(item.Id);
             Assert.IsNull(dbItem);

--- a/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/Delete.Test.cs
+++ b/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/Delete.Test.cs
@@ -88,10 +88,10 @@ namespace Microsoft.Zumo.Server.Test.TableController
         }
 
         [TestMethod]
-        public async Task DeleteItem_Unauthorized_Returns404()
+        public async Task DeleteItem_Unauthorized_Returns403()
         {
             var response = await SendRequestToServer<E2EServer.DataObjects.Movie>(HttpMethod.Delete, "/tables/unauthorized/movie-3", null);
-            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [TestMethod]

--- a/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/List.Test.cs
+++ b/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/List.Test.cs
@@ -104,10 +104,10 @@ namespace Microsoft.Zumo.Server.Test.TableController
         }
 
         [TestMethod]
-        public async Task GetItems_Unauthorzed_Returns404()
+        public async Task GetItems_Unauthorzed_Returns403()
         {
             var response = await SendRequestToServer<Movie>(HttpMethod.Get, "/tables/unauthorized", null);
-            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [TestMethod]

--- a/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/Read.Test.cs
+++ b/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/Read.Test.cs
@@ -51,11 +51,11 @@ namespace Microsoft.Zumo.Server.Test.TableController
         }
         
         [TestMethod]
-        public async Task ReadItemAsync_NotAuthorized_Returns404()
+        public async Task ReadItemAsync_NotAuthorized_Returns403()
         {
             var response = await SendRequestToServer<Movie>(HttpMethod.Get, $"/tables/unauthorized/{Movie4.Id}", null);
 
-            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [TestMethod]

--- a/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/Replace.Test.cs
+++ b/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController/Replace.Test.cs
@@ -73,11 +73,11 @@ namespace Microsoft.Zumo.Server.Test.TableController
         }
 
         [TestMethod]
-        public async Task ReplaceItem_Unauthorized_Returns404()
+        public async Task ReplaceItem_Unauthorized_Returns403()
         {
             var item = GetItemFromDb<E2EServer.DataObjects.Movie>("movie-8");
             var response = await SendRequestToServer<E2EServer.DataObjects.Movie>(HttpMethod.Put, $"/tables/unauthorized/{item.Id}", item);
-            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [TestMethod]


### PR DESCRIPTION
* Refactored `ValidateOperationAsync` so that it calls `ValidateOperation` & `IsAuthorized` in the right order
* Refactored `PrepareItemForStoreasync` so that it calls `PrepareItemForStore`
* Updated tests to compensate for "Forbidden" HTTP status code.