### PR TITLE
(#164) Moved the client generation code into ServiceRestClient

### DIFF
--- a/dotnet/client/src/Microsoft.Zumo.MobileData/Internal/ServiceRestClient{T}.cs
+++ b/dotnet/client/src/Microsoft.Zumo.MobileData/Internal/ServiceRestClient{T}.cs
@@ -1,0 +1,293 @@
+﻿using Azure;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Zumo.MobileData.Internal
+{
+    /// <summary>
+    /// Provides the underlying RESTful operations for a Table controller,
+    /// without interpreting the results.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class ServiceRestClient<T> where T : TableData
+    {
+        public ServiceRestClient(Uri endpoint, TokenCredential credential, MobileTableClientOptions options)
+        {
+            Arguments.IsAbsoluteUri(endpoint, nameof(endpoint));
+            Arguments.IsNotNull(options, nameof(options));
+
+            Endpoint = endpoint;
+            SerializerOptions = options.JsonSerializerOptions;
+
+            var perCallPolicies = new List<HttpPipelinePolicy>();
+            var perRetryPolicies = new List<HttpPipelinePolicy>();
+
+            // Add the authentication policy only if supplied a credential.
+            if (credential != null)
+            {
+                var scope = $"{endpoint.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped)}/.default";
+                perRetryPolicies.Add(new BearerTokenAuthenticationPolicy(credential, scope));
+            }
+
+            // Builds the pipeline based on the policies provided.
+            Pipeline = HttpPipelineBuilder.Build(options, perCallPolicies.ToArray(), perRetryPolicies.ToArray(), new ResponseClassifier());
+        }
+
+        /// <summary>
+        /// The base <see cref="Uri"/> for the backend table controller.
+        /// </summary>
+        internal Uri Endpoint { get; }
+
+        /// <summary>
+        /// The <see cref="JsonSerializerOptions"/> for encoding the requests.
+        /// </summary>
+        internal JsonSerializerOptions SerializerOptions { get; }
+
+        /// <summary>
+        /// The Azure.Core Pipeline used for communicating with to the service
+        /// </summary>
+        internal HttpPipeline Pipeline { get; }
+
+        /// <summary>
+        /// Helper method to send the request to the remote service.
+        /// </summary>
+        /// <param name="request">The request to send</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        internal Response SendRequest(Request request, CancellationToken cancellationToken)
+            => Pipeline.SendRequest(request, cancellationToken);
+
+        /// <summary>
+        /// Helper method to send the request to the remote service.
+        /// </summary>
+        /// <param name="request">The request to send</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        internal ValueTask<Response> SendRequestAsync(Request request, CancellationToken cancellationToken)
+            => Pipeline.SendRequestAsync(request, cancellationToken);
+
+        /// <summary>
+        /// Creates a request object for a paged response.
+        /// </summary>
+        /// <param name="query">The query to send</param>
+        /// <param name="pageLink">The link to the next page</param>
+        /// <returns>The <see cref="Request"/> object corresponding to the request</returns>
+        internal Request CreateGetMetadataRequest(MobileTableQueryOptions query)
+        {
+            Request request = Pipeline.CreateRequest();
+            request.Method = RequestMethod.Get;
+            var builder = request.Uri;
+            builder.Reset(Endpoint);
+            if (query.Filter != null)
+            {
+                builder.AppendQuery("$filter", query.Filter);
+            }
+            if (query.OrderBy != null)
+            {
+                builder.AppendQuery("$orderBy", query.OrderBy);
+            }
+            if (query.IncludeDeleted)
+            {
+                builder.AppendQuery("__includedeleted", "true");
+            }
+            builder.AppendQuery("$count", "true");
+            builder.AppendQuery("__excludeitems", "true");
+
+            return request;
+        }
+
+        /// <summary>
+        /// Creates the request for a DELETE operation
+        /// </summary>
+        /// <param name="item">The item to delete</param>
+        /// <param name="conditions">The <see cref="MatchConditions"/> for this request, if any</param>
+        /// <returns></returns>
+        internal Request CreateDeleteRequest(T item, MatchConditions conditions)
+        {
+            Request request = Pipeline.CreateRequest();
+
+            request.Method = RequestMethod.Delete;
+            request.BuildUri(Endpoint, item.Id);
+            request.ApplyConditionalHeaders(conditions ?? new MatchConditions { IfMatch = new ETag(item.Version) });
+
+            return request;
+        }
+
+        /// <summary>
+        /// Creates a request for a GET ITEM operation
+        /// </summary>
+        /// <param name="id">The ID of the entity to retrieve</param>
+        /// <param name="requestOptions">The <see cref="MatchConditions"/> for this request, if any</param>
+        /// <returns>A pageable list of items</returns>
+        internal Request CreateGetRequest(string id, MatchConditions requestOptions)
+        {
+            Request request = Pipeline.CreateRequest();
+
+            request.Method = RequestMethod.Get;
+            request.BuildUri(Endpoint, id);
+            request.ApplyConditionalHeaders(requestOptions);
+
+            return request;
+        }
+
+        /// <summary>
+        /// Creates a request object for a paged response.
+        /// </summary>
+        /// <param name="options">The query to send</param>
+        /// <param name="pageLink">The link to the next page</param>
+        /// <returns>The <see cref="Request"/> object corresponding to the request</returns>
+        internal Request CreateListRequest(MobileTableQueryOptions options, string pageLink)
+        {
+            Request request = Pipeline.CreateRequest();
+            request.Method = RequestMethod.Get;
+            if (pageLink != null)
+            {
+                request.Uri.Reset(new Uri(pageLink));
+            }
+            else
+            {
+                var builder = request.Uri;
+                builder.Reset(Endpoint);
+                if (options != null)
+                {
+                    if (options.Filter != null)
+                    {
+                        builder.AppendQuery("$filter", options.Filter);
+                    }
+                    if (options.OrderBy != null)
+                    {
+                        builder.AppendQuery("$orderBy", options.OrderBy);
+                    }
+                    if (options.Skip >= 0)
+                    {
+                        builder.AppendQuery("$skip", $"{options.Skip}");
+                    }
+                    if (options.Size >= 0)
+                    {
+                        builder.AppendQuery("$top", $"{options.Size}");
+                    }
+                    if (options.IncludeDeleted)
+                    {
+                        builder.AppendQuery("__includedeleted", "true");
+                    }
+                    if (options.IncludeCount)
+                    {
+                        builder.AppendQuery("$count", "true");
+                    }
+                }
+            }
+            return request;
+        }
+
+        /// <summary>
+        /// Creates a POST item (Create/Insert) operation request.
+        /// </summary>
+        /// <param name="item">The item to insert</param>
+        /// <returns>A <see cref="Request"/> object ready for transmission</returns>
+        internal Request CreateInsertRequest(T item)
+        {
+            Request request = Pipeline.CreateRequest();
+
+            request.Method = RequestMethod.Post;
+            request.BuildUri(Endpoint, null);
+            request.ApplyConditionalHeaders(new MatchConditions { IfNoneMatch = ETag.All });
+            request.Headers.Add(HttpHeader.Common.JsonContentType);
+            request.Content = CreateRequestContent(item);
+
+            return request;
+        }
+
+        /// <summary>
+        /// Creates a PUT item (Replace) operation request.
+        /// </summary>
+        /// <param name="item">The item to replace</param>
+        /// <returns>A <see cref="Request"/> object ready for transmission</returns>
+        internal Request CreateReplaceRequest(T item, MatchConditions requestOptions)
+        {
+            Request request = Pipeline.CreateRequest();
+
+            request.Method = RequestMethod.Put;
+            request.BuildUri(Endpoint, item.Id);
+            request.ApplyConditionalHeaders(requestOptions ?? new MatchConditions { IfMatch = new ETag(item.Version) });
+            request.Headers.Add(HttpHeader.Common.JsonContentType);
+            request.Content = CreateRequestContent(item);
+
+            return request;
+        }
+
+        /// <summary>
+        /// Serializes an item into it's JSON form, ready for transmission.
+        /// </summary>
+        /// <param name="item">The item to serialize.</param>
+        /// <returns>A set of UTF-8 bytes to transmit.</returns>
+        private RequestContent CreateRequestContent(T item)
+            => RequestContent.Create(JsonSerializer.SerializeToUtf8Bytes<T>(item, SerializerOptions));
+
+        /// <summary>
+        /// Creates a typed response from an untyped response with an IO Stream
+        /// </summary>
+        /// <param name="response">The response to process</param>
+        /// <param name="cancellationToken">A lifecycle cancellation token</param>
+        /// <returns>The typed response</returns>
+        internal Task<Response<T>> CreateResponseAsync(Response response, CancellationToken cancellationToken)
+            => CreateResponseAsync<T>(response, cancellationToken);
+
+        /// <summary>
+        /// Creates a typed response from an untyped response with an IO Stream
+        /// </summary>
+        /// <typeparam name="U">The type of the model</typeparam>
+        /// <param name="response">The response to process</param>
+        /// <param name="cancellationToken">A lifecycle cancellation token</param>
+        /// <returns>The typed response</returns>
+        internal async Task<Response<U>> CreateResponseAsync<U>(Response response, CancellationToken cancellationToken) where U : class
+        {
+            U result = await JsonSerializer.DeserializeAsync<U>(response.ContentStream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+            return Response.FromValue(result, response);
+        }
+
+        /// <summary>
+        /// Creates a typed response from an untyped response with an IO Stream
+        /// </summary>
+        /// <param name="response">The response to process</param>
+        /// <param name="cancellationToken">A lifecycle cancellation token</param>
+        /// <returns>The typed response</returns>
+        internal Response<T> CreateResponse(Response response, CancellationToken cancellationToken)
+            => CreateResponse<T>(response, cancellationToken);
+
+        /// <summary>
+        /// Creates a typed response from an untyped response with an IO Stream
+        /// </summary>
+        /// <typeparam name="U">The type of the model</typeparam>
+        /// <param name="response">The response to process</param>
+        /// <param name="cancellationToken">A lifecycle cancellation token</param>
+        /// <returns>The typed response</returns>
+        internal Response<U> CreateResponse<U>(Response response, CancellationToken cancellationToken) where U : class
+        {
+            var result = JsonSerializer.DeserializeAsync<U>(response.ContentStream, SerializerOptions, cancellationToken);
+            return Response.FromValue(result.Result, response);
+        }
+
+        /// <summary>
+        /// Deserializes the content of the response into a <see cref="PagedResult{T}"/> object.
+        /// </summary>
+        /// <param name="response">The response to process</param>
+        /// <param name="cancellationToken">A lifecycle cancellation token</param>
+        /// <returns></returns>
+        internal ValueTask<PagedResult<T>> CreatePagedResultAsync(Response response, CancellationToken cancellationToken)
+            => JsonSerializer.DeserializeAsync<PagedResult<T>>(response.ContentStream, SerializerOptions, cancellationToken);
+
+        /// <summary>
+        /// Deserializes the content of the response into a <see cref="PagedResult{T}"/> object.
+        /// </summary>
+        /// <param name="response">The response to process</param>
+        /// <param name="cancellationToken">A lifecycle cancellation token</param>
+        /// <returns></returns>
+        internal PagedResult<T> CreatePagedResult(Response response, CancellationToken cancellationToken)
+            => JsonSerializer.DeserializeAsync<PagedResult<T>>(response.ContentStream, SerializerOptions, cancellationToken).Result;
+    }
+}

--- a/dotnet/client/src/Microsoft.Zumo.MobileData/Table/ConflictException{T}.cs
+++ b/dotnet/client/src/Microsoft.Zumo.MobileData/Table/ConflictException{T}.cs
@@ -27,8 +27,7 @@ namespace Microsoft.Zumo.MobileData
                 ETag = headers.ETag.Value;
             }
 
-            string lastModifiedHeader;
-            if (headers.TryGetValue("Last-Modified", out lastModifiedHeader))
+            if (headers.TryGetValue("Last-Modified", out string lastModifiedHeader))
             {
                 LastModified = DateTimeOffset.Parse(lastModifiedHeader);
             }

--- a/dotnet/client/src/Microsoft.Zumo.MobileData/Table/MobileTable{T}.cs
+++ b/dotnet/client/src/Microsoft.Zumo.MobileData/Table/MobileTable{T}.cs
@@ -3,11 +3,8 @@
 
 using Azure;
 using Azure.Core;
-using Azure.Core.Pipeline;
 using Microsoft.Zumo.MobileData.Internal;
 using System;
-using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,47 +25,13 @@ namespace Microsoft.Zumo.MobileData
         {
             Arguments.IsAbsoluteUri(endpoint, nameof(endpoint));
 
-            Credential = client.Credential;
-            ClientOptions = client.ClientOptions;
-            Endpoint = endpoint;
-
-            var perCallPolicies = new List<HttpPipelinePolicy>();
-            var perRetryPolicies = new List<HttpPipelinePolicy>();
-
-            // Add the authentication policy only if supplied a credential.
-            if (Credential != null)
-            {
-                var scope = $"{Endpoint.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped)}/.default";
-                perRetryPolicies.Add(new BearerTokenAuthenticationPolicy(Credential, scope));
-            }
-
-            // Builds the pipeline based on the policies provided.
-            Pipeline = HttpPipelineBuilder.Build(
-                ClientOptions, 
-                perCallPolicies.ToArray(), 
-                perRetryPolicies.ToArray(), 
-                new ResponseClassifier());
+            Client = new ServiceRestClient<T>(endpoint, client.Credential, client.ClientOptions);
         }
 
         /// <summary>
-        /// The base <see cref="Uri"/> for the backend table controller.
+        /// The REST Client used for communicating with to the service
         /// </summary>
-        internal Uri Endpoint { get; }
-
-        /// <summary>
-        /// The credential to use for authorization.
-        /// </summary>
-        internal TokenCredential Credential { get; }
-
-        /// <summary>
-        /// The client options for this connection.
-        /// </summary>
-        internal MobileTableClientOptions ClientOptions { get; }
-
-        /// <summary>
-        /// The Azure.Core Pipeline used for communicating with to the service
-        /// </summary>
-        internal HttpPipeline Pipeline { get; }
+        internal ServiceRestClient<T> Client { get; }
 
         #region GetMetadata
         /// <summary>
@@ -89,12 +52,12 @@ namespace Microsoft.Zumo.MobileData
         {
             Arguments.IsNotNull(query, nameof(query));
 
-            using Request request = CreateGetMetadataRequest(query);
-            Response response = await Pipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            using Request request = Client.CreateGetMetadataRequest(query);
+            Response response = await Client.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             return response.Status switch
             {
-                200 => await CreateResponseAsync<MobileTableMetadata>(response, cancellationToken).ConfigureAwait(false),
+                200 => await Client.CreateResponseAsync<MobileTableMetadata>(response, cancellationToken).ConfigureAwait(false),
                 _ => throw new RequestFailedException(response.Status, response.ReasonPhrase),
             };
         }
@@ -117,44 +80,14 @@ namespace Microsoft.Zumo.MobileData
         {
             Arguments.IsNotNull(query, nameof(query));
 
-            using Request request = CreateGetMetadataRequest(query);
-            Response response = Pipeline.SendRequest(request, cancellationToken);
+            using Request request = Client.CreateGetMetadataRequest(query);
+            Response response = Client.SendRequest(request, cancellationToken);
 
             return response.Status switch
             {
-                200 => CreateResponse<MobileTableMetadata>(response, cancellationToken),
+                200 => Client.CreateResponse<MobileTableMetadata>(response, cancellationToken),
                 _ => throw new RequestFailedException(response.Status, response.ReasonPhrase),
             };
-        }
-
-        /// <summary>
-        /// Creates a request object for a paged response.
-        /// </summary>
-        /// <param name="query">The query to send</param>
-        /// <param name="pageLink">The link to the next page</param>
-        /// <returns>The <see cref="Request"/> object corresponding to the request</returns>
-        private Request CreateGetMetadataRequest(MobileTableQueryOptions query)
-        {
-            Request request = Pipeline.CreateRequest();
-            request.Method = RequestMethod.Get;
-            var builder = request.Uri;
-            builder.Reset(Endpoint);
-            if (query.Filter != null)
-            {
-                builder.AppendQuery("$filter", query.Filter);
-            }
-            if (query.OrderBy != null)
-            {
-                builder.AppendQuery("$orderBy", query.OrderBy);
-            }
-            if (query.IncludeDeleted)
-            {
-                builder.AppendQuery("__includedeleted", "true");
-            }
-            builder.AppendQuery("$count", "true");
-            builder.AppendQuery("__excludeitems", "true");
-
-            return request;
         }
         #endregion
 
@@ -171,8 +104,8 @@ namespace Microsoft.Zumo.MobileData
             Arguments.IsNotNull(item, nameof(item));
             Arguments.IsNotNullOrEmpty(item.Id, nameof(item.Id));
 
-            using Request request = CreateDeleteRequest(item, conditions ?? new MatchConditions { IfMatch = new ETag(item.Version) });
-            Response response = await Pipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            using Request request = Client.CreateDeleteRequest(item, conditions);
+            Response response = await Client.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             switch (response.Status)
             {
@@ -180,7 +113,7 @@ namespace Microsoft.Zumo.MobileData
                 case 204:
                     return response;
                 case 412:
-                    throw new ConflictException<T>(CreateResponse(response, cancellationToken));
+                    throw new ConflictException<T>(Client.CreateResponse(response, cancellationToken));
                 default:
                     throw new RequestFailedException(response.Status, response.ReasonPhrase);
             }
@@ -198,8 +131,8 @@ namespace Microsoft.Zumo.MobileData
             Arguments.IsNotNull(item, nameof(item));
             Arguments.IsNotNullOrEmpty(item.Id, nameof(item.Id));
 
-            using Request request = CreateDeleteRequest(item, conditions ?? new MatchConditions { IfMatch = new ETag(item.Version) });
-            Response response = Pipeline.SendRequest(request, cancellationToken);
+            using Request request = Client.CreateDeleteRequest(item, conditions);
+            Response response = Client.Pipeline.SendRequest(request, cancellationToken);
 
             switch (response.Status)
             {
@@ -207,27 +140,10 @@ namespace Microsoft.Zumo.MobileData
                 case 204:
                     return response;
                 case 412:
-                    throw new ConflictException<T>(CreateResponse(response, cancellationToken));
+                    throw new ConflictException<T>(Client.CreateResponse(response, cancellationToken));
                 default:
                     throw new RequestFailedException(response.Status, response.ReasonPhrase);
             }
-        }
-
-        /// <summary>
-        /// Creates the request for a DELETE operation
-        /// </summary>
-        /// <param name="item">The item to delete</param>
-        /// <param name="conditions">The <see cref="MatchConditions"/> for this request, if any</param>
-        /// <returns></returns>
-        private Request CreateDeleteRequest(T item, MatchConditions conditions)
-        {
-            Request request = Pipeline.CreateRequest();
-
-            request.Method = RequestMethod.Delete;
-            request.BuildUri(Endpoint, item.Id);
-            request.ApplyConditionalHeaders(conditions);
-
-            return request;
         }
         #endregion
 
@@ -242,12 +158,12 @@ namespace Microsoft.Zumo.MobileData
         {
             Arguments.IsNotNullOrEmpty(id, nameof(id));
 
-            using Request request = CreateGetRequest(id, default);
-            Response response = await Pipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            using Request request = Client.CreateGetRequest(id, default);
+            Response response = await Client.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             return response.Status switch
             {
-                200 => await CreateResponseAsync(response, cancellationToken).ConfigureAwait(false),
+                200 => await Client.CreateResponseAsync(response, cancellationToken).ConfigureAwait(false),
                 _ => throw new RequestFailedException(response.Status, response.ReasonPhrase),
             };
         }
@@ -262,31 +178,14 @@ namespace Microsoft.Zumo.MobileData
         {
             Arguments.IsNotNullOrEmpty(id, nameof(id));
 
-            using Request request = CreateGetRequest(id, default);
-            Response response = Pipeline.SendRequest(request, cancellationToken);
+            using Request request = Client.CreateGetRequest(id, default);
+            Response response = Client.SendRequest(request, cancellationToken);
 
             return response.Status switch
             {
-                200 => CreateResponse(response, cancellationToken),
+                200 => Client.CreateResponse(response, cancellationToken),
                 _ => throw new RequestFailedException(response.Status, response.ReasonPhrase),
             };
-        }
-
-        /// <summary>
-        /// Creates a request for a GET ITEM operation
-        /// </summary>
-        /// <param name="id">The ID of the entity to retrieve</param>
-        /// <param name="requestOptions">The <see cref="MatchConditions"/> for this request, if any</param>
-        /// <returns>A pageable list of items</returns>
-        private Request CreateGetRequest(string id, MatchConditions requestOptions)
-        {
-            Request request = Pipeline.CreateRequest();
-
-            request.Method = RequestMethod.Get;
-            request.BuildUri(Endpoint, id);
-            request.ApplyConditionalHeaders(requestOptions);
-
-            return request;
         }
         #endregion
 
@@ -322,13 +221,13 @@ namespace Microsoft.Zumo.MobileData
         /// <returns>A single page of results</returns>
         private async Task<Page<T>> GetItemsPageAsync(MobileTableQueryOptions options, string pageLink, CancellationToken cancellationToken = default)
         {
-            using Request request = CreateListRequest(options, pageLink);
-            Response response = await Pipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            using Request request = Client.CreateListRequest(options, pageLink);
+            Response response = await Client.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             switch (response.Status)
             {
                 case 200:
-                    PagedResult<T> data = await CreatePagedResultAsync(response, cancellationToken).ConfigureAwait(false);
+                    PagedResult<T> data = await Client.CreatePagedResultAsync(response, cancellationToken).ConfigureAwait(false);
                     return Page<T>.FromValues(data.Values, data.NextLink, response);
                 default:
                     throw new RequestFailedException(response.Status, response.ReasonPhrase);
@@ -344,66 +243,17 @@ namespace Microsoft.Zumo.MobileData
         /// <returns>A single page of results</returns>
         private Page<T> GetItemsPage(MobileTableQueryOptions options, string pageLink, CancellationToken cancellationToken = default)
         {
-            using Request request = CreateListRequest(options, pageLink);
-            Response response = Pipeline.SendRequest(request, cancellationToken);
+            using Request request = Client.CreateListRequest(options, pageLink);
+            Response response = Client.SendRequest(request, cancellationToken);
 
             switch (response.Status)
             {
                 case 200:
-                    PagedResult<T> data = CreatePagedResult(response, cancellationToken);
+                    PagedResult<T> data = Client.CreatePagedResult(response, cancellationToken);
                     return Page<T>.FromValues(data.Values, data.NextLink, response);
                 default:
                     throw new RequestFailedException(response.Status, response.ReasonPhrase);
             }
-        }
-
-        /// <summary>
-        /// Creates a request object for a paged response.
-        /// </summary>
-        /// <param name="options">The query to send</param>
-        /// <param name="pageLink">The link to the next page</param>
-        /// <returns>The <see cref="Request"/> object corresponding to the request</returns>
-        private Request CreateListRequest(MobileTableQueryOptions options, string pageLink)
-        {
-            Request request = Pipeline.CreateRequest();
-            request.Method = RequestMethod.Get;
-            if (pageLink != null)
-            {
-                request.Uri.Reset(new Uri(pageLink));
-            } 
-            else
-            {
-                var builder = request.Uri;
-                builder.Reset(Endpoint);
-                if (options != null)
-                {
-                    if (options.Filter != null)
-                    {
-                        builder.AppendQuery("$filter", options.Filter);
-                    }
-                    if (options.OrderBy != null)
-                    {
-                        builder.AppendQuery("$orderBy", options.OrderBy);
-                    }
-                    if (options.Skip >= 0)
-                    {
-                        builder.AppendQuery("$skip", $"{options.Skip}");
-                    }
-                    if (options.Size >= 0)
-                    {
-                        builder.AppendQuery("$top", $"{options.Size}");
-                    }
-                    if (options.IncludeDeleted)
-                    {
-                        builder.AppendQuery("__includedeleted", "true");
-                    }
-                    if (options.IncludeCount)
-                    {
-                        builder.AppendQuery("$count", "true");
-                    }
-                }
-            }
-            return request;
         }
         #endregion
 
@@ -419,16 +269,16 @@ namespace Microsoft.Zumo.MobileData
         {
             Arguments.IsNotNull(item, nameof(item));
 
-            using Request request = CreateInsertRequest(item);
-            Response response = await Pipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            using Request request = Client.CreateInsertRequest(item);
+            Response response = await Client.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             switch (response.Status)
             {
                 case 201:
-                    return await CreateResponseAsync(response, cancellationToken).ConfigureAwait(false);
+                    return await Client.CreateResponseAsync(response, cancellationToken).ConfigureAwait(false);
                 case 409:
                 case 412:
-                    throw new ConflictException<T>(await CreateResponseAsync(response, cancellationToken).ConfigureAwait(false));
+                    throw new ConflictException<T>(await Client.CreateResponseAsync(response, cancellationToken).ConfigureAwait(false));
                 default:
                     throw new RequestFailedException(response.Status, response.ReasonPhrase);
             }
@@ -445,37 +295,19 @@ namespace Microsoft.Zumo.MobileData
         {
             Arguments.IsNotNull(item, nameof(item));
 
-            using Request request = CreateInsertRequest(item);
-            Response response = Pipeline.SendRequest(request, cancellationToken);
+            using Request request = Client.CreateInsertRequest(item);
+            Response response = Client.SendRequest(request, cancellationToken);
 
             switch (response.Status)
             {
                 case 201:
-                    return CreateResponse(response, cancellationToken);
+                    return Client.CreateResponse(response, cancellationToken);
                 case 409:
                 case 412:
-                    throw new ConflictException<T>(CreateResponse(response, cancellationToken));
+                    throw new ConflictException<T>(Client.CreateResponse(response, cancellationToken));
                 default:
                     throw new RequestFailedException(response.Status, response.ReasonPhrase);
             }
-        }
-
-        /// <summary>
-        /// Creates a POST item (Create/Insert) operation request.
-        /// </summary>
-        /// <param name="item">The item to insert</param>
-        /// <returns>A <see cref="Request"/> object ready for transmission</returns>
-        private Request CreateInsertRequest(T item)
-        {
-            Request request = Pipeline.CreateRequest();
-
-            request.Method = RequestMethod.Post;
-            request.BuildUri(Endpoint, null);
-            request.ApplyConditionalHeaders(new MatchConditions { IfNoneMatch = ETag.All });
-            request.Headers.Add(HttpHeader.Common.JsonContentType);
-            request.Content = CreateRequestContent(item);
-
-            return request;
         }
         #endregion
 
@@ -493,16 +325,16 @@ namespace Microsoft.Zumo.MobileData
             Arguments.IsNotNull(item, nameof(item));
             Arguments.IsNotNull(item.Id, nameof(item.Id));
 
-            using Request request = CreateReplaceRequest(item, conditions ?? new MatchConditions { IfMatch = new ETag(item.Version) });
-            Response response = await Pipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            using Request request = Client.CreateReplaceRequest(item, conditions);
+            Response response = await Client.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
             switch (response.Status)
             {
                 case 200:
-                    return await CreateResponseAsync(response, cancellationToken).ConfigureAwait(false);
+                    return await Client.CreateResponseAsync(response, cancellationToken).ConfigureAwait(false);
                 case 409:
                 case 412:
-                    throw new ConflictException<T>(await CreateResponseAsync(response, cancellationToken).ConfigureAwait(false));
+                    throw new ConflictException<T>(await Client.CreateResponseAsync(response, cancellationToken).ConfigureAwait(false));
                 default:
                     throw new RequestFailedException(response.Status, response.ReasonPhrase);
             }
@@ -521,104 +353,20 @@ namespace Microsoft.Zumo.MobileData
             Arguments.IsNotNull(item, nameof(item));
             Arguments.IsNotNull(item.Id, nameof(item.Id));
 
-            using Request request = CreateReplaceRequest(item, conditions ?? new MatchConditions { IfMatch = new ETag(item.Version) });
-            Response response = Pipeline.SendRequest(request, cancellationToken);
+            using Request request = Client.CreateReplaceRequest(item, conditions);
+            Response response = Client.SendRequest(request, cancellationToken);
 
             switch (response.Status)
             {
                 case 200:
-                    return CreateResponse(response, cancellationToken);
+                    return Client.CreateResponse(response, cancellationToken);
                 case 409:
                 case 412:
-                    throw new ConflictException<T>(CreateResponse(response, cancellationToken));
+                    throw new ConflictException<T>(Client.CreateResponse(response, cancellationToken));
                 default:
                     throw new RequestFailedException(response.Status, response.ReasonPhrase);
             }
         }
-
-        /// <summary>
-        /// Creates a PUT item (Replace) operation request.
-        /// </summary>
-        /// <param name="item">The item to replace</param>
-        /// <returns>A <see cref="Request"/> object ready for transmission</returns>
-        private Request CreateReplaceRequest(T item, MatchConditions requestOptions)
-        {
-            Request request = Pipeline.CreateRequest();
-
-            request.Method = RequestMethod.Put;
-            request.BuildUri(Endpoint, item.Id);
-            request.ApplyConditionalHeaders(requestOptions);
-            request.Headers.Add(HttpHeader.Common.JsonContentType);
-            request.Content = CreateRequestContent(item);
-
-            return request;
-        }
-        #endregion
-
-        #region CreateResponse & CreateRequest
-        /// <summary>
-        /// Creates a typed response from an untyped response with an IO Stream
-        /// </summary>
-        /// <param name="response">The response to process</param>
-        /// <param name="cancellationToken">A lifecycle cancellation token</param>
-        /// <returns>The typed response</returns>
-        private Task<Response<T>> CreateResponseAsync(Response response, CancellationToken cancellationToken)
-            => CreateResponseAsync<T>(response, cancellationToken);
-
-        /// <summary>
-        /// Creates a typed response from an untyped response with an IO Stream
-        /// </summary>
-        /// <typeparam name="U">The type of the model</typeparam>
-        /// <param name="response">The response to process</param>
-        /// <param name="cancellationToken">A lifecycle cancellation token</param>
-        /// <returns>The typed response</returns>
-        private async Task<Response<U>> CreateResponseAsync<U>(Response response, CancellationToken cancellationToken) where U : class
-        {
-            U result = await JsonSerializer.DeserializeAsync<U>(response.ContentStream, ClientOptions.JsonSerializerOptions, cancellationToken).ConfigureAwait(false);
-            return Response.FromValue(result, response);
-        }
-
-        /// <summary>
-        /// Creates a typed response from an untyped response with an IO Stream
-        /// </summary>
-        /// <param name="response">The response to process</param>
-        /// <param name="cancellationToken">A lifecycle cancellation token</param>
-        /// <returns>The typed response</returns>
-        private Response<T> CreateResponse(Response response, CancellationToken cancellationToken)
-            => CreateResponse<T>(response, cancellationToken);
-
-        /// <summary>
-        /// Creates a typed response from an untyped response with an IO Stream
-        /// </summary>
-        /// <typeparam name="U">The type of the model</typeparam>
-        /// <param name="response">The response to process</param>
-        /// <param name="cancellationToken">A lifecycle cancellation token</param>
-        /// <returns>The typed response</returns>
-        private Response<U> CreateResponse<U>(Response response, CancellationToken cancellationToken) where U : class
-        {
-            var result = JsonSerializer.DeserializeAsync<U>(response.ContentStream, ClientOptions.JsonSerializerOptions, cancellationToken);
-            return Response.FromValue(result.Result, response);
-        }
-
-        private ValueTask<PagedResult<T>> CreatePagedResultAsync(Response response, CancellationToken cancellationToken)
-           => JsonSerializer.DeserializeAsync<PagedResult<T>>(response.ContentStream, ClientOptions.JsonSerializerOptions, cancellationToken);
-
-        /// <summary>
-        /// Deserializes the content of the response into a <see cref="PagedResult{T}"/> object.
-        /// </summary>
-        /// <param name="response">The response to process</param>
-        /// <param name="cancellationToken">A lifecycle cancellation token</param>
-        /// <returns></returns>
-        private PagedResult<T> CreatePagedResult(Response response, CancellationToken cancellationToken)
-            => JsonSerializer.DeserializeAsync<PagedResult<T>>(response.ContentStream, ClientOptions.JsonSerializerOptions, cancellationToken).Result;
-
-        /// <summary>
-        /// Serializes an item into it's JSON form, ready for transmission.
-        /// </summary>
-        /// <param name="item">The item to serialize.</param>
-        /// <returns>A set of UTF-8 bytes to transmit.</returns>
-        private RequestContent CreateRequestContent(T item)
-            => RequestContent.Create(JsonSerializer.SerializeToUtf8Bytes<T>(item, ClientOptions.JsonSerializerOptions));
         #endregion
     }
 }

--- a/dotnet/client/test/Microsoft.Zumo.MobileData.Test/Helpers/HttpAssert.cs
+++ b/dotnet/client/test/Microsoft.Zumo.MobileData.Test/Helpers/HttpAssert.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Core;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
 
 namespace Microsoft.Zumo.MobileData.Test.Helpers
 {
@@ -10,11 +10,10 @@ namespace Microsoft.Zumo.MobileData.Test.Helpers
     {
         internal static void HeaderIsEqual(string headerName, string headerValue, Request request)
         {
-            string actual;
-            var isPresent = request.Headers.TryGetValue(headerName, out actual);
-            Assert.IsTrue(isPresent);
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(headerValue, actual);
+            var isPresent = request.Headers.TryGetValue(headerName, out string actual);
+            Debug.Assert(isPresent, $"Expected header {headerName} to be present in response");
+            Debug.Assert(actual != null, $"Value of header {headerName} is null");
+            Debug.Assert(actual.Equals(headerValue), $"Expected {headerName} value to be \"{headerValue}\", Actual \"{actual}\"");
         }
     }
 }

--- a/dotnet/client/test/Microsoft.Zumo.MobileData.Test/Internal/RequestExtensions.Test.cs
+++ b/dotnet/client/test/Microsoft.Zumo.MobileData.Test/Internal/RequestExtensions.Test.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Zumo.MobileData.Test
         {
             var client = new MobileTableClient(new Uri("https://localhost:5001"));
             var table = client.GetTable<Movie>();
-            var request = table.Pipeline.CreateRequest();
+            var request = table.Client.Pipeline.CreateRequest();
             var conditions = new MatchConditions { IfMatch = new ETag("foo") };
             request.ApplyConditionalHeaders(conditions);
             HttpAssert.HeaderIsEqual("If-Match", "\"foo\"", request);
@@ -28,7 +28,7 @@ namespace Microsoft.Zumo.MobileData.Test
         {
             var client = new MobileTableClient(new Uri("https://localhost:5001"));
             var table = client.GetTable<Movie>();
-            var request = table.Pipeline.CreateRequest();
+            var request = table.Client.Pipeline.CreateRequest();
             var conditions = new MatchConditions { IfNoneMatch = new ETag("foo") };
             request.ApplyConditionalHeaders(conditions);
             HttpAssert.HeaderIsEqual("If-None-Match", "\"foo\"", request);
@@ -39,7 +39,7 @@ namespace Microsoft.Zumo.MobileData.Test
         {
             var client = new MobileTableClient(new Uri("https://localhost:5001"));
             var table = client.GetTable<Movie>();
-            var request = table.Pipeline.CreateRequest();
+            var request = table.Client.Pipeline.CreateRequest();
             var conditions = new MatchConditions { IfMatch = ETag.All };
             request.ApplyConditionalHeaders(conditions);
             HttpAssert.HeaderIsEqual("If-Match", "*", request);
@@ -50,7 +50,7 @@ namespace Microsoft.Zumo.MobileData.Test
         {
             var client = new MobileTableClient(new Uri("https://localhost:5001"));
             var table = client.GetTable<Movie>();
-            var request = table.Pipeline.CreateRequest();
+            var request = table.Client.Pipeline.CreateRequest();
             var conditions = new MatchConditions { IfNoneMatch = ETag.All };
             request.ApplyConditionalHeaders(conditions);
             HttpAssert.HeaderIsEqual("If-None-Match", "*", request);
@@ -61,7 +61,7 @@ namespace Microsoft.Zumo.MobileData.Test
         {
             var client = new MobileTableClient(new Uri("https://localhost:5001"));
             var table = client.GetTable<Movie>();
-            var request = table.Pipeline.CreateRequest();
+            var request = table.Client.Pipeline.CreateRequest();
             var conditions = new MatchConditions { IfMatch = new ETag("foo"), IfNoneMatch = new ETag("bar") };
             request.ApplyConditionalHeaders(conditions);
             HttpAssert.HeaderIsEqual("If-Match", "\"foo\"", request);
@@ -73,7 +73,7 @@ namespace Microsoft.Zumo.MobileData.Test
         {
             var client = new MobileTableClient(new Uri("https://localhost:5001"));
             var table = client.GetTable<Movie>();
-            var request = table.Pipeline.CreateRequest();
+            var request = table.Client.Pipeline.CreateRequest();
             var conditions = new RequestConditions { IfModifiedSince = DateTimeOffset.Parse("2020-01-01T07:30:06Z") };
             request.ApplyConditionalHeaders(conditions);
             HttpAssert.HeaderIsEqual("If-Modified-Since", "Wed, 01 Jan 2020 07:30:06 GMT", request);
@@ -84,7 +84,7 @@ namespace Microsoft.Zumo.MobileData.Test
         {
             var client = new MobileTableClient(new Uri("https://localhost:5001"));
             var table = client.GetTable<Movie>();
-            var request = table.Pipeline.CreateRequest();
+            var request = table.Client.Pipeline.CreateRequest();
             var conditions = new RequestConditions { IfUnmodifiedSince = DateTimeOffset.Parse("2020-01-01T07:30:06Z") };
             request.ApplyConditionalHeaders(conditions);
             HttpAssert.HeaderIsEqual("If-Unmodified-Since", "Wed, 01 Jan 2020 07:30:06 GMT", request);

--- a/dotnet/client/test/Microsoft.Zumo.MobileData.Test/MobileDataClientOptions.Test.cs
+++ b/dotnet/client/test/Microsoft.Zumo.MobileData.Test/MobileDataClientOptions.Test.cs
@@ -12,11 +12,13 @@ namespace Microsoft.Zumo.MobileData.Test
         [TestMethod]
         public void SetJsonSerializerOptions_RoundTrips()
         {
-            var actual = new MobileTableClientOptions();
-            actual.JsonSerializerOptions = new JsonSerializerOptions
+            var actual = new MobileTableClientOptions
             {
-                IgnoreNullValues = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                JsonSerializerOptions = new JsonSerializerOptions
+                {
+                    IgnoreNullValues = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                }
             };
 
             Assert.IsTrue(actual.JsonSerializerOptions.IgnoreNullValues);

--- a/dotnet/server/src/Microsoft.Zumo.Server/TableController.cs
+++ b/dotnet/server/src/Microsoft.Zumo.Server/TableController.cs
@@ -57,11 +57,7 @@ namespace Microsoft.Zumo.Server
         /// <param name="tableRepository">The <see cref="ITableRepository{TEntity}"/> for the backend store.</param>
         protected TableController(ITableRepository<TEntity> tableRepository): this()
         {
-            if (tableRepository == null)
-            {
-                throw new ArgumentNullException(nameof(tableRepository));
-            }
-            this.tableRepository = tableRepository;
+            this.tableRepository = tableRepository ?? throw new ArgumentNullException(nameof(tableRepository));
         }
 
         /// <summary>
@@ -79,15 +75,11 @@ namespace Microsoft.Zumo.Server
             }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
                 if (tableRepository != null)
                 {
                     throw new InvalidOperationException("TableRepository cannot be set twice.");
                 }
-                tableRepository = value;
+                tableRepository = value ?? throw new ArgumentNullException(nameof(value));
             }
         }
 

--- a/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController.Test.cs
+++ b/dotnet/server/test/Microsoft.Zumo.Server.Test/TableController.Test.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Zumo.Server.Test
         public void TableRepository_ThrowsIfSetNull()
         {
             var context = MovieDbContext.InMemoryContext();
-            _ = new MoviesController(context)
+            _ = new MoviesController()
             {
                 TableRepository = null
             };


### PR DESCRIPTION
* Created `Internal/ServiceRestClient<T>` class with all the pipeline code.
* Refactored the `MobileTableClient<T>` to use the ServiceRestClient.
* Updated tests relying on pipeline to grab the pipeline from the right place inside the client.