### PR TITLE
Assigned text color to "listItemTitle" style

### DIFF
--- a/samples/xamarin-forms/ZumoQuickstart/ZumoQuickstart/App.xaml
+++ b/samples/xamarin-forms/ZumoQuickstart/ZumoQuickstart/App.xaml
@@ -16,6 +16,7 @@
             <Style x:Key="listItemTitle" TargetType="Label">
                 <Setter Property="HorizontalOptions" Value="FillAndExpand" />
                 <Setter Property="VerticalOptions" Value="Center" />
+                <Setter Property="TextColor" Value="Black" />
             </Style>
             <Style x:Key="listItemIcon" TargetType="Image">
                 <Setter Property="Source" Value="completed.png" />


### PR DESCRIPTION
The text color for the `Label` control with the dark theme enabled is _white_, so it does not show up with the _azure_ background color.