### PR TITLE
Forced to execute logic on the main thread

### DIFF
--- a/samples/xamarin-forms/ZumoQuickstart/ZumoQuickstart/TodoListViewModel.cs
+++ b/samples/xamarin-forms/ZumoQuickstart/ZumoQuickstart/TodoListViewModel.cs
@@ -29,18 +29,21 @@ namespace ZumoQuickstart
 
         private void OnServiceUpdated(object sender, TodoListEventArgs e)
         {
-            switch (e.Action)
+            Device.BeginInvokeOnMainThread(new Action(async () =>
             {
-                case TodoListAction.Add:
-                    Items.Add(e.Item);
-                    break;
-                case TodoListAction.Delete:
-                    Items.RemoveIf(m => m.Id == e.Item.Id);
-                    break;
-                case TodoListAction.Update:
-                    Items.ReplaceIf(m => m.Id == e.Item.Id, e.Item);
-                    break;
-            }
+                switch (e.Action)
+                {
+                    case TodoListAction.Add:
+                        Items.Add(e.Item);
+                        break;
+                    case TodoListAction.Delete:
+                        Items.RemoveIf(m => m.Id == e.Item.Id);
+                        break;
+                    case TodoListAction.Update:
+                        Items.ReplaceIf(m => m.Id == e.Item.Id, e.Item);
+                        break;
+                }
+            }));
         }
 
         /// <summary>


### PR DESCRIPTION
When you add a new TODO item `TodoService.AddTodoItemAsync` makes these two calls:

```csharp
await mTable.InsertAsync(item).ConfigureAwait(false); 
OnTodoListChanged(TodoListAction.Add, item);
```

When you press an item to mark it as done/undone, `TodoService.UpdateTodoItemAsync`  makes these two calls:

```csharp
await mTable.UpdateAsync(item).ConfigureAwait(false); 
OnTodoListChanged(TodoListAction.Add, item);
```

Those `ConfigureAwait(false)` causes that the current context after the call is no longer that of the Main Thread, so when `OnTodoListChanged` is called, it runs in the thread of execution in which `IMobileServiceTable<TodoItem>.InsertAsync` or `IMobileServiceTable<TodoItem>.UpdateAsync` has been executed and, in UWP, this causes that `TodoListViewModel.OnServiceUpdated` throws an exception of type: 

```
The application called an interface that was marshalled for a different thread.
```

One solution would be to remove `ConfigureAwait(false)` but this does not make sense in a service that has nothing to do with the user interface.

The proposed solution is to make the `OnServiceUpdated` logic running in the context of the Main Thread.

