### PR TITLE
(#548) Fixed the RemoteTable<T> constructor to bypass contract resolver creation when used as part of a projection.

### DIFF
--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Extensions/ITableQueryExtensions.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Extensions/ITableQueryExtensions.cs
@@ -18,6 +18,14 @@ namespace Microsoft.Datasync.Client
     public static class ITableQueryExtensions
     {
         /// <summary>
+        /// Converts the table query to an OData string.
+        /// </summary>
+        /// <param name="includeParameters">Include the parameters.</param>
+        /// <returns>The OData string.</returns>
+        internal static string ToODataString<T>(this ITableQuery<T> query, bool includeParameters = true)
+            => (query as TableQuery<T>)!.ToODataString();
+
+        /// <summary>
         /// Creates an array from the result of a table query.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>

--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Query/OData/QueryDescriptionExtensions.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Query/OData/QueryDescriptionExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Datasync.Client.Query.OData
 
             if (value.Selection.Count > 0)
             {
-                queryFragments.Add($"{ODataOptions.Select}={string.Join(",", value.Selection.Select(Uri.EscapeDataString))}");
+                queryFragments.Add($"{ODataOptions.Select}={string.Join(",", value.Selection.OrderBy(field => field).Select(Uri.EscapeDataString))}");
             }
 
             if (value.IncludeTotalCount)

--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Query/TableQuery.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Query/TableQuery.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Datasync.Client.Query
         /// <returns>The composed query object.</returns>
         public ITableQuery<U> Select<U>(Expression<Func<T, U>> selector)
         {
-            IRemoteTable<U> remoteTable = new RemoteTable<U>(RemoteTable.TableName, RemoteTable.ServiceClient);
+            IRemoteTable<U> remoteTable = new RemoteTable<U>(RemoteTable.TableName, RemoteTable.ServiceClient, isProjection: true);
             return new TableQuery<U>(remoteTable, Query.Select(selector), Parameters, RequestTotalCount) { IsOfflineEnabled = IsOfflineEnabled };
         }
 

--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Table/RemoteTable.generic.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Table/RemoteTable.generic.cs
@@ -26,14 +26,17 @@ namespace Microsoft.Datasync.Client.Table
         /// </summary>
         /// <param name="tableName">The name of the table.</param>
         /// <param name="serviceClient">The service client that created this table.</param>
-        internal RemoteTable(string tableName, DatasyncClient serviceClient) : base(tableName, serviceClient)
+        internal RemoteTable(string tableName, DatasyncClient serviceClient, bool isProjection = false) : base(tableName, serviceClient)
         {
-            // ResolveTableName has a side effect of initializing the contract in the contract resolver,
-            // so call it here to ensure initialization.
-            serviceClient.Serializer.ResolveTableName<T>();
+            if (!isProjection)
+            {
+                // ResolveTableName has a side effect of initializing the contract in the contract resolver,
+                // so call it here to ensure initialization.
+                serviceClient.Serializer.ResolveTableName<T>();
 
-            // Ensure that the Id field in T is a String.
-            ServiceSerializer.EnsureIdIsString<T>();
+                // Ensure that the Id field in T is a String.
+                ServiceSerializer.EnsureIdIsString<T>();
+            }
         }
 
         #region IRemoteTable<T>

--- a/sdk/dotnet/test/Microsoft.Datasync.Client.Test/Query/Linq.Test.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Client.Test/Query/Linq.Test.cs
@@ -1,16 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License.
 
-using Datasync.Common.Test;
-using Datasync.Common.Test.Models;
 using Microsoft.Datasync.Client.Query;
 using Microsoft.Datasync.Client.Table;
 using Microsoft.Datasync.Client.Test.Helpers;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/sdk/dotnet/test/Microsoft.Datasync.Client.Test/Query/TableQuery.Test.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Client.Test/Query/TableQuery.Test.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Datasync.Client.Test.Query
             var client = GetMockClient();
             RemoteTable<IdEntity> table = client.GetRemoteTable<IdEntity>("movies") as RemoteTable<IdEntity>;
             var query = new TableQuery<IdEntity>(table);
-            var actual = query.Select(m => new IdOnly { Id = m.Id }) as TableQuery<IdOnly>;
+            var actual = query.Select(m => new IdOnly { Id = m.Id });
             Assert.IsAssignableFrom<MethodCallExpression>(actual.Query.Expression);
             var expression = actual.Query.Expression as MethodCallExpression;
             Assert.Equal("Select", expression.Method.Name);
@@ -241,9 +241,21 @@ namespace Microsoft.Datasync.Client.Test.Query
         {
             var client = GetMockClient();
             RemoteTable<IdEntity> table = client.GetRemoteTable<IdEntity>("movies") as RemoteTable<IdEntity>;
-            var query = new TableQuery<IdEntity>(table).Select(m => new IdOnly { Id = m.Id }) as TableQuery<IdOnly>;
+            var query = new TableQuery<IdEntity>(table).Select(m => new IdOnly { Id = m.Id });
             var odata = query.ToODataString();
             Assert.Equal("$select=id", odata);
+        }
+
+        [Fact]
+        [Trait("Method", "ToODataString")]
+        [Trait("Method", "Select")]
+        public void ToODataString_Select_NoId_IsWellFormed()
+        {
+            var client = GetMockClient();
+            RemoteTable<ClientMovie> table = client.GetRemoteTable<ClientMovie>("movies") as RemoteTable<ClientMovie>;
+            var query = table.CreateQuery().Select(m => new { m.Title, m.ReleaseDate });
+            var odata = query.ToODataString();
+            Assert.Equal("$select=releaseDate,title", odata);
         }
 
         [Theory, CombinatorialData]


### PR DESCRIPTION
Closes #548