### PR TITLE
[SQLiteStore] Accept SQLITE_MISUSE for sqlite3_config(SQLITE_CONFIG_URI, 1)

### DIFF
--- a/sdk/dotnet/src/Microsoft.Datasync.Client.SQLiteStore/Driver/SqliteConnection.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client.SQLiteStore/Driver/SqliteConnection.cs
@@ -42,9 +42,12 @@ namespace Microsoft.Datasync.Client.SQLiteStore.Driver
                 Batteries_V2.Init();
 
                 // You only need to configure the sqlite3 interface once.
-                if (raw.sqlite3_config(raw.SQLITE_CONFIG_URI, 1) != raw.SQLITE_OK)
+                // NOTE: SQLITE_MISUSE is accepted as valid result code because it could mean,
+                // that SQLITE_CONFIG_URI is already set (eg. from another library).
+                var resultCode = raw.sqlite3_config(raw.SQLITE_CONFIG_URI, 1);
+                if (resultCode != raw.SQLITE_OK && resultCode != raw.SQLITE_MISUSE)
                 {
-                    throw new SQLiteException("Unable to configure sqlite3 for URI connection strings.");
+                    throw new SQLiteException($"Unable to configure sqlite3 for URI connection strings. Result code : {resultCode}");
                 }
 
                 sqliteIsInitialized = true;


### PR DESCRIPTION
This PR fixes a crash when using the library along with another library which consumes `SQLitePCL.raw`.
The library should not throw exception if `raw.sqlite3_config(raw.SQLITE_CONFIG_URI, 1)` returns `SQLITE_MISUSE` as it would mean that the config was already set.
See https://github.com/microsoft/appcenter-sdk-dotnet/issues/1725#issuecomment-1411559479 for details.

https://github.com/Azure/azure-mobile-apps/issues/573
https://github.com/microsoft/appcenter-sdk-dotnet/issues/1725


---
_NOTE: I haven't tested the changes._