### PR TITLE
(#610) Server side enums serialized as strings.

### DIFF
--- a/sdk/dotnet/src/Microsoft.AspNetCore.Datasync/Extensions/AspNetCoreExtensions.cs
+++ b/sdk/dotnet/src/Microsoft.AspNetCore.Datasync/Extensions/AspNetCoreExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Datasync.Converters;
 using Microsoft.AspNetCore.OData;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using System;
 
@@ -47,6 +48,7 @@ namespace Microsoft.AspNetCore.Datasync
                     options.SerializerSettings.Converters.Add(new JSelectExpandWrapperConverter());
                     options.SerializerSettings.Converters.Add(new JDynamicTypeWrapperConverter());
                     options.SerializerSettings.Converters.Add(new DateTimeOffsetJsonConverter());
+                    options.SerializerSettings.Converters.Add(new StringEnumConverter());
                 });
 
             return services;

--- a/sdk/dotnet/test/Datasync.Common.Test/Models/KitchenSink.cs
+++ b/sdk/dotnet/test/Datasync.Common.Test/Models/KitchenSink.cs
@@ -6,6 +6,13 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Datasync.Common.Test.Models
 {
+    public enum KitchenSinkState
+    {
+        None,
+        Completed,
+        Failed
+    }
+
     /// <summary>
     /// A model used for validation tests.  It contains one of 
     /// every single supported type in a nullable form.
@@ -30,9 +37,13 @@ namespace Datasync.Common.Test.Models
         public char CharValue { get; set; }
         public string? StringValue { get; set; }
 
+        // Enums
+        public KitchenSinkState EnumValue { get; set; }
+
         // Complex types
         public DateTime? DateTimeValue { get; set; }
         public DateTimeOffset? DateTimeOffsetValue { get; set; }
         public Guid? GuidValue { get; set; }
+
     }
 }

--- a/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Helpers/Models.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Helpers/Models.cs
@@ -34,6 +34,13 @@ namespace Microsoft.Datasync.Integration.Test.Helpers
         public string Id { get; set; }
     }
 
+    public enum KitchenSinkDtoState
+    {
+        None,
+        Completed,
+        Failed
+    }
+
     [ExcludeFromCodeCoverage]
     public class KitchenSinkDto : DatasyncClientData
     {
@@ -58,6 +65,9 @@ namespace Microsoft.Datasync.Integration.Test.Helpers
         public DateTime? DateTimeValue { get; set; }
         public DateTimeOffset? DateTimeOffsetValue { get; set; }
         public Guid? GuidValue { get; set; }
+
+        // Enums
+        public KitchenSinkDtoState EnumValue { get; set; }
     }
 
     [ExcludeFromCodeCoverage]

--- a/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/KitchenSink/BaseOperationTest.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/KitchenSink/BaseOperationTest.cs
@@ -1,16 +1,18 @@
-﻿using Datasync.Common.Test.Models;
+﻿// Copyright (c) Microsoft Corporation. All Rights Reserved.
+// Licensed under the MIT License.
+
+using Castle.Core.Logging;
 using Datasync.Common.Test;
+using Microsoft.Datasync.Client;
 using Microsoft.Datasync.Client.SQLiteStore;
+using Microsoft.Datasync.Integration.Test.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
+using System.IO;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
-using Microsoft.Datasync.Client;
-using System.IO;
-using Microsoft.Datasync.Integration.Test.Helpers;
 
 namespace Microsoft.Datasync.Integration.Test.KitchenSink
 {
@@ -24,6 +26,7 @@ namespace Microsoft.Datasync.Integration.Test.KitchenSink
         protected readonly DatasyncClient client;
         protected IOfflineTable<KitchenSinkDto>? offlineTable;
         protected IRemoteTable<KitchenSinkDto> remoteTable;
+        protected Mock<ILogger<OfflineSQLiteStore>> storeLoggerMock;
 
         protected BaseOperationTest(ITestOutputHelper logger, bool useFile = true)
         {
@@ -37,7 +40,10 @@ namespace Microsoft.Datasync.Integration.Test.KitchenSink
             {
                 connectionString = "file:in-memory.db?mode=memory";
             }
-            store = new OfflineSQLiteStore(connectionString);
+
+            storeLoggerMock = new Mock<ILogger<OfflineSQLiteStore>>();
+            storeLoggerMock.Setup(x => x.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<object>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception?, string>>()));
+            store = new OfflineSQLiteStore(connectionString, storeLoggerMock.Object);
             store.DefineTable<KitchenSinkDto>("kitchensink");
             client = GetMovieClient(store: store);
             remoteTable = client.GetRemoteTable<KitchenSinkDto>("kitchensink");


### PR DESCRIPTION
* Added service serializer for string enums
* Added round-trip test for enums as strings
* Added kitchensink test for enum query as string.