### PR TITLE
Bugfix for deserializing nullable enum properties.

### DIFF
--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Offline/AbstractOfflineStore.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Offline/AbstractOfflineStore.cs
@@ -130,6 +130,14 @@ namespace Microsoft.Datasync.Client.Offline
                         contractProperty.ValueProvider.SetValue(definition, firstValue);
                     }
                 }
+                else if (contractProperty.PropertyType.IsNullableEnum(out var enumPropertyType))
+                {
+                    object firstValue = Enum.GetValues(enumPropertyType).Cast<object>().FirstOrDefault();
+                    if (firstValue != null)
+                    {
+                        contractProperty.ValueProvider.SetValue(definition, firstValue);
+                    }
+                }
             }
 
             // Create a JObject out of the definition.

--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Utils/StdLibExtensions.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Utils/StdLibExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Datasync.Client.Utils
         /// <param name="type">The subject type.</param>
         /// <param name="enumPropertyType">On return, the first generic attribute which is contains the Enum type itself.</param>
         /// <returns><c>true</c> if the subject type enum of nullable, <c>false</c> otherwise.</returns>
-        internal static bool IsNullableEnum(this Type type, out Type? enumPropertyType)
+        internal static bool IsNullableEnum(this Type type, out Type enumPropertyType)
         {
             if (type.IsGenericType &&
                 type.GetGenericTypeDefinition() == typeof(Nullable<>) &&

--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Utils/StdLibExtensions.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Utils/StdLibExtensions.cs
@@ -33,6 +33,26 @@ namespace Microsoft.Datasync.Client.Utils
         }
 
         /// <summary>
+        /// Determines if the type Nullable{Enum}.
+        /// </summary>
+        /// <param name="type">The subject type.</param>
+        /// <param name="enumPropertyType">On return, the first generic attribute which is contains the Enum type itself.</param>
+        /// <returns><c>true</c> if the subject type enum of nullable, <c>false</c> otherwise.</returns>
+        internal static bool IsNullableEnum(this Type type, out Type? enumPropertyType)
+        {
+            if (type.IsGenericType &&
+                type.GetGenericTypeDefinition() == typeof(Nullable<>) &&
+                type.GetGenericArguments()[0].IsEnum)
+            {
+                enumPropertyType = type.GetGenericArguments()[0];
+                return true;
+            }
+
+            enumPropertyType = default;
+            return false;
+        }
+
+        /// <summary>
         /// Normalize an endpoint by removing any query and fragment, then ensuring that the
         /// path has a trailing slash.
         /// </summary>

--- a/sdk/dotnet/test/Datasync.Common.Test/Models/KitchenSink.cs
+++ b/sdk/dotnet/test/Datasync.Common.Test/Models/KitchenSink.cs
@@ -41,6 +41,9 @@ public class KitchenSink : EntityTableData
     // Enums
     public KitchenSinkState EnumValue { get; set; }
 
+    // Nullable Enums
+    public KitchenSinkState? EnumOfNullableValue { get; set; } // Nullable<KitchenSinkState>
+
     // Complex types
     public DateTime? DateTimeValue { get; set; }
     public DateTimeOffset? DateTimeOffsetValue { get; set; }

--- a/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Helpers/Models.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Helpers/Models.cs
@@ -64,6 +64,9 @@ public class KitchenSinkDto : DatasyncClientData
 
     // Enums
     public KitchenSinkDtoState EnumValue { get; set; }
+
+    // Nullable Enums
+    public KitchenSinkDtoState? EnumOfNullableValue { get; set; } // Nullable<KitchenSinkDtoState>
 }
 
 [ExcludeFromCodeCoverage]

--- a/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/KitchenSink/KitchenSink.Test.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/KitchenSink/KitchenSink.Test.cs
@@ -13,15 +13,15 @@ namespace Microsoft.Datasync.Integration.Test.KitchenSink;
 [ExcludeFromCodeCoverage]
 public class KitchenSink_Tests : BaseOperationTest
 {
-    public KitchenSink_Tests(ITestOutputHelper logger) : base(logger) 
-    { 
+    public KitchenSink_Tests(ITestOutputHelper logger) : base(logger)
+    {
     }
 
     [Fact]
     public async Task KS1_NullRoundtrips()
     {
         // On client 1
-        KitchenSinkDto client1dto = new() { StringValue = "This is a string" };
+        KitchenSinkDto client1dto = new() { StringValue = "This is a string", EnumOfNullableValue = KitchenSinkDtoState.Completed };
         await remoteTable.InsertItemAsync(client1dto);
         var remoteId = client1dto.Id;
         Assert.NotEmpty(remoteId);
@@ -33,6 +33,7 @@ public class KitchenSink_Tests : BaseOperationTest
         var client2dto = await offlineTable.GetItemAsync(remoteId);
         Assert.NotNull(client2dto);
         Assert.Equal("This is a string", client2dto.StringValue);
+        Assert.Equal(KitchenSinkDtoState.Completed, client2dto.EnumOfNullableValue);
 
         // Now update client 1
         client1dto = await remoteTable.GetItemAsync(remoteId);
@@ -46,6 +47,8 @@ public class KitchenSink_Tests : BaseOperationTest
         Assert.NotNull(client2dto);
         // Issue 408 - cannot replace a string with a null.
         Assert.Null(client2dto.StringValue);
+
+        Assert.NotNull(client2dto.EnumOfNullableValue);
 
         // Check log statements here
         Assert.True(storeLoggerMock.Invocations.Count > 0);
@@ -99,7 +102,7 @@ public class KitchenSink_Tests : BaseOperationTest
         // On client 1
         for (int i = 1; i <= 50; i++)
         {
-            KitchenSinkDto dto = new() { StringValue = $"String {i}", IntValue = i };
+            KitchenSinkDto dto = new() { StringValue = $"String {i}", IntValue = i, EnumOfNullableValue = null, };
             await remoteTable.InsertItemAsync(dto);
         }
 


### PR DESCRIPTION

Scenario of:
```

    enum SomethingEnum { A, B, C }

    class TestOfNullableEnums
    {
        public SomethingEnum? TestEnumNullable { get; set; } // Nullable<SomethingEnum>
        public SomethingEnum TestEnum { get; set; }

        public int Id { get; set; } // placeholder
    }
```

The table definition would be INTEGER for TestEnumNullable property and TEXT for TestEnum property. And table API data could not be deseralized on client side and stored in SQLite of:
```
 ..[ ... {  "testEnumNullable": null, "testEnum": "B", ...  } .. ].. 
```

