### PR TITLE
(#797) expand table operation errors to all JSON errors.

### DIFF
--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Offline/Queue/TableOperationError.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Offline/Queue/TableOperationError.cs
@@ -199,9 +199,9 @@ namespace Microsoft.Datasync.Client.Offline.Queue
                 {
                     result = JsonConvert.DeserializeObject<JObject>(rawResult, serializerSettings);
                 }
-                catch (JsonReaderException)
+                catch (JsonException)
                 {
-                    // Ignore JsonReaderException, because 'rawResult' might not be JSON.
+                    // Ignore JsonException, because 'rawResult' might not be JSON.
                 }
             }
 


### PR DESCRIPTION
Closes #797 