### PR TITLE
(#877) Add IN support for Remote Tables

### DIFF
--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Query/OData/ODataExpressionVisitor.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Query/OData/ODataExpressionVisitor.cs
@@ -89,6 +89,15 @@ namespace Microsoft.Datasync.Client.Query.OData
         /// <returns>The visited node</returns>
         public override QueryNode Visit(FunctionCallNode node)
         {
+            // Special case: string[].Contains(string) is represented as "string in ( string, string, ...)" in OData
+            if (node.Name == "in")
+            {
+                Accept(node, node.Arguments[1]);
+                Expression.Append(" in ");
+                Accept(node, node.Arguments[0]);
+                return node;
+            }
+
             bool appendSeparator = false;
             Expression.Append(node.Name).Append('(');
             foreach (QueryNode arg in node.Arguments)

--- a/sdk/dotnet/test/Microsoft.Datasync.Client.Test/Query/Linq.Test.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Client.Test/Query/Linq.Test.cs
@@ -171,6 +171,16 @@ public class Linq_Tests : ClientBaseTest
         );
     }
 
+    [Fact]
+    public void Linq_Contains()
+    {
+        string[] ratings = new string[] { "A", "B" };
+        ExecuteWhereQuery(
+            m => ratings.Contains(m.StringProperty),
+            "$filter=stringProperty%20in%20%28%27A%27%2C%27B%27%29"
+        );
+    }
+
     private void ExecuteWhereQuery(Expression<Func<KitchenSink, bool>> predicate, string expected)
     {
         var sut = _query.Where(predicate);

--- a/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Client/OfflineTableOfT/GetAsyncItems.Test.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Client/OfflineTableOfT/GetAsyncItems.Test.cs
@@ -1143,7 +1143,7 @@ public class GetAsyncItems_Tests
         );
     }
 
-    [Fact]
+    [Fact(Skip = "Needs OData parser updates in SqliteStore to work")]
     public async Task ToAsyncEnumerable_Linq_where_101()
     {
         string[] ratings = new string[] { "G", "PG" };

--- a/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Client/OfflineTableOfT/GetAsyncItems.Test.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Client/OfflineTableOfT/GetAsyncItems.Test.cs
@@ -1144,6 +1144,17 @@ public class GetAsyncItems_Tests
     }
 
     [Fact]
+    public async Task ToAsyncEnumerable_Linq_where_101()
+    {
+        string[] ratings = new string[] { "G", "PG" };
+        await RunLinqTest(
+            m => m.Where(x => ratings.Contains(x.Rating)),
+            50,
+            new[] { "id-010", "id-015", "id-024", "id-026", "id-027" }
+        );
+    }
+
+    [Fact]
     public async Task ToAsyncEnumerable_Linq_where_120()
     {
         await RunLinqTest(

--- a/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Client/RemoteTableOfT/GetAsyncItems.Test.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Client/RemoteTableOfT/GetAsyncItems.Test.cs
@@ -4,6 +4,7 @@
 using Datasync.Common.Test.TestData;
 using Microsoft.Datasync.Client.Query;
 using Microsoft.Datasync.Client.Table;
+using System.Reflection;
 
 // These are explicit tests in the set.
 #pragma warning disable RCS1033 // Remove redundant boolean literal.
@@ -1163,6 +1164,17 @@ public class GetAsyncItems_Tests
             m => m.Where(x => (x.Title + x.Rating) == "Fight ClubR"),
             1,
             new string[] { "id-009" }
+        );
+    }
+
+    [Fact]
+    public async Task ToAsyncEnumerable_Linq_where_101()
+    {
+        string[] ratings = new string[] { "G", "PG" };
+        await RunLinqTest(
+            m => m.Where(x => ratings.Contains(x.Rating)),
+            50,
+            new[] { "id-010", "id-015", "id-024", "id-026", "id-027" }
         );
     }
 

--- a/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Server/Query.Test.cs
+++ b/sdk/dotnet/test/Microsoft.Datasync.Integration.Test/Server/Query.Test.cs
@@ -3681,6 +3681,18 @@ public class Query_Tests : BaseTest
     }
 
     [Fact]
+    public async Task Query_Test_307()
+    {
+        await BaseQueryTest(
+            "tables/movies?$filter=rating in ('G', 'PG')&$count=true",
+            50,
+            null,
+            50,
+            new[] { "id-010", "id-015", "id-024", "id-026", "id-027" }
+        );
+    }
+
+    [Fact]
     public async Task Query_AuthTest_001()
     {
         await BaseQueryTest(


### PR DESCRIPTION
Adds support for the following:

```csharp
var ratings = new string[] { "A", "B" };
var items = remoteTable.Where(x => ratings.Contains(x.Rating)).ToAsyncEnumerable();
```

The offline version of this DOES NOT work (there is a skipped test around it).