### PR TITLE
Fix success condition in SendPushFinishedEvent call, fix its documentation

### DIFF
--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Offline/SyncContext.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Offline/SyncContext.cs
@@ -586,7 +586,7 @@ namespace Microsoft.Datasync.Client.Offline
             {
                 batch.OtherErrors.Add(new OfflineStoreException("Failed to read errors from the local store.", ex));
             }
-            SendPushFinishedEvent(batchStatus != PushStatus.Complete);
+            SendPushFinishedEvent(batchStatus == PushStatus.Complete);
 
             // If the push did not complete successfully, then throw a PushFailedException.
             if (batchStatus != PushStatus.Complete || batch.HasErrors(errors))

--- a/sdk/dotnet/src/Microsoft.Datasync.Client/Offline/SynchronizationEventArgs.cs
+++ b/sdk/dotnet/src/Microsoft.Datasync.Client/Offline/SynchronizationEventArgs.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Datasync.Client.Offline
         public string TableName { get; internal set; }
 
         /// <summary>
-        /// In the case of a result, whether the push was successful or not.
+        /// In the case of a result, whether it was successful or not.
+        /// Events with a result are ItemWasPushed, ItemWasStored, PullFinished and PushFinished 
         /// </summary>
         public bool? IsSuccessful { get; internal set; }
     }


### PR DESCRIPTION
SendPushFinishedEvent was being called with `success: false` when `batchStatus` equaled to `PushStatus.Complete`.

However, I think it should be `success: true` when `batchStatus` equals to `PushStatus.Complete`

Fixes #924
Fixes #923